### PR TITLE
NOJIRA: Bump version to v2.0.4-rc.3; sync repo version with npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ucbg",
-  "version": "2.0.4-rc.2",
+  "version": "2.0.4-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ucbg",
-  "version": "2.0.4-rc.2",
+  "version": "2.0.4-rc.3",
   "description": "UC Botanical Garden profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",


### PR DESCRIPTION
Bumping version again to sync repo version with npm.
v2.0.4-rc.2 was published in 06/16/2023.