### PR TITLE
DRYD-1895: added phenological observation group of fields 

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -2,6 +2,8 @@ import { defineMessages } from 'react-intl';
 
 export default (configContext) => {
   const {
+    AutocompleteInput,
+    CompoundInput,
     DateInput,
     OptionPickerInput,
     TextInput,
@@ -701,6 +703,122 @@ export default (configContext) => {
             dataType: DATA_TYPE_BOOL,
             view: {
               type: CheckboxInput,
+            },
+          },
+        },
+        phenologicalObservationGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          phenologicalObservationGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_botgarden.phenologicalObservationGroup.name',
+                  defaultMessage: 'Phenological observation',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+              },
+            },
+            observationDate: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.collectionobjects_botgarden.observationDate.name',
+                    defaultMessage: 'Date',
+                  },
+                  fullName: {
+                    id: 'field.collectionobjects_botgarden.observationDate.fullName',
+                    defaultMessage: 'Phenological observation date',
+                  },
+                }),
+                dataType: DATA_TYPE_DATE,
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            observationPhenophase: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.collectionobjects_botgarden.observationPhenophase.name',
+                    defaultMessage: 'Phenophase',
+                  },
+                  fullName: {
+                    id: 'field.collectionobjects_botgarden.observationPhenophase.fullName',
+                    defaultMessage: 'Phenological observation phenophase',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'observationphenophase',
+                  },
+                },
+              },
+            },
+            observationQuantity: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.collectionobjects_botgarden.observationQuantity.name',
+                    defaultMessage: 'Quantity',
+                  },
+                  fullName: {
+                    id: 'field.collectionobjects_botgarden.observationQuantity.fullName',
+                    defaultMessage: 'Phenological observation quantity',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'observationquantity',
+                  },
+                },
+              },
+            },
+            observationBy: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.collectionobjects_botgarden.observationBy.name',
+                    defaultMessage: 'Observation by',
+                  },
+                  fullName: {
+                    id: 'field.collectionobjects_botgarden.observationBy.fullName',
+                    defaultMessage: 'Phenological observation by',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/shared',
+                  },
+                },
+              },
+            },
+            observationNote: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.collectionobjects_botgarden.observationNote.name',
+                    defaultMessage: 'Note',
+                  },
+                  fullName: {
+                    id: 'field.collectionobjects_botgarden.observationNote.fullName',
+                    defaultMessage: 'Phenological observation note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
             },
           },
         },

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -714,12 +714,6 @@ export default (configContext) => {
           },
           phenologicalObservationGroup: {
             [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.collectionobjects_botgarden.phenologicalObservationGroup.name',
-                  defaultMessage: 'Phenological observation',
-                },
-              }),
               repeating: true,
               view: {
                 type: CompoundInput,

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -193,17 +193,19 @@ const template = (configContext) => {
             <Field name="fragrance" subpath="ns2:collectionobjects_botgarden" />
           </Row>
 
-          <Field name="phenologicalObservationGroupList" subpath="ns2:collectionobjects_botgarden">
-            <Field name="phenologicalObservationGroup">
-              <Row>
-                <Field name="observationDate" />
-                <Field name="observationPhenophase" />
-                <Field name="observationQuantity" />
-                <Field name="observationNote" />
-                <Field name="observationBy" />
-              </Row>
+          <Panel name="phenologicalObservations" collapsible collapsed>
+            <Field name="phenologicalObservationGroupList" subpath="ns2:collectionobjects_botgarden">
+              <Field name="phenologicalObservationGroup">
+                <Row>
+                  <Field name="observationDate" />
+                  <Field name="observationPhenophase" />
+                  <Field name="observationQuantity" />
+                  <Field name="observationNote" />
+                  <Field name="observationBy" />
+                </Row>
+              </Field>
             </Field>
-          </Field>
+          </Panel>
 
           <Row>
             <Field name="flowersJan" subpath="ns2:collectionobjects_botgarden" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -193,6 +193,18 @@ const template = (configContext) => {
             <Field name="fragrance" subpath="ns2:collectionobjects_botgarden" />
           </Row>
 
+          <Field name="phenologicalObservationGroupList" subpath="ns2:collectionobjects_botgarden">
+            <Field name="phenologicalObservationGroup">
+              <Row>
+                <Field name="observationDate" />
+                <Field name="observationPhenophase" />
+                <Field name="observationQuantity" />
+                <Field name="observationNote" />
+                <Field name="observationBy" />
+              </Row>
+            </Field>
+          </Field>
+
           <Row>
             <Field name="flowersJan" subpath="ns2:collectionobjects_botgarden" />
             <Field name="flowersFeb" subpath="ns2:collectionobjects_botgarden" />

--- a/src/plugins/recordTypes/collectionobject/messages.js
+++ b/src/plugins/recordTypes/collectionobject/messages.js
@@ -21,6 +21,10 @@ export default (configContext) => {
           id: 'panel.collectionobject.accessionAttributes',
           defaultMessage: 'Accession Attributes',
         },
+        phenologicalObservations: {
+          id: 'panel.collectionobject.phenologicalObservations',
+          defaultMessage: 'Phenological Observations',
+        },
       }),
       ...extensions['ucbnh-collectionobject'].messages.panel,
     },


### PR DESCRIPTION
**What does this do?**
The updates include:
* adding `phenologicalObservationGroup` repeating group of fields to the default collection object template
* wrapping the fields to a collapsible panel so to avoid any UX issues of too many rows of fields

**Why are we doing this? (with JIRA link)**
We need to replace the existing fruit and flower monthly block of fields with a repeating block of fields that hold broader phenological observations: 
https://collectionspace.atlassian.net/browse/DRYD-1895
https://collectionspace.atlassian.net/browse/DRYD-1896
https://collectionspace.atlassian.net/browse/DRYD-1897

**How should this be tested? Do these changes have associated tests?**
Please confirm 
* That the fields are being populated as expected
* The wrapping panel is by default collapsed and the state of it (collapsed/expaned) persists over sessions
* The Phenophase and Quantity dynamic lists and the Observation by authority field are populated as expected
* The dynamic lists are editable through the Tools > Term Lists

**Dependencies for merging? Releasing to production?**
https://github.com/cspace-deployment/application/pull/205 needs to be merged and released.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi tested locally.