### PR TITLE
DRYD-2035 Object Record > Bot Garden > Add Other Number Block

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -35,6 +35,67 @@ export default (configContext) => {
             },
           },
         },
+        otherNumberList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          otherNumber: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.otherNumber.name',
+                  defaultMessage: 'Other number',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            numberValue: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.numberValue.fullName',
+                    defaultMessage: 'Other number value',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.numberValue.name',
+                    defaultMessage: 'Value',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            numberType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.numberType.fullName',
+                    defaultMessage: 'Other number type',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.numberType.name',
+                    defaultMessage: 'Type',
+                  },
+                }),
+                view: {
+                  type: OptionPickerInput,
+                  props: {
+                    source: 'ucbgNumberTypes',
+                  },
+                },
+              },
+            },
+          },
+        },
         briefDescriptions: {
           briefDescription: {
             [config]: {

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -36,56 +36,9 @@ export default (configContext) => {
           },
         },
         otherNumberList: {
-          [config]: {
-            view: {
-              type: CompoundInput,
-            },
-          },
           otherNumber: {
-            [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.collectionobjects_common.otherNumber.name',
-                  defaultMessage: 'Other number',
-                },
-              }),
-              repeating: true,
-              view: {
-                type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
-              },
-            },
-            numberValue: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.collectionobjects_common.numberValue.fullName',
-                    defaultMessage: 'Other number value',
-                  },
-                  name: {
-                    id: 'field.collectionobjects_common.numberValue.name',
-                    defaultMessage: 'Value',
-                  },
-                }),
-                view: {
-                  type: TextInput,
-                },
-              },
-            },
             numberType: {
               [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.collectionobjects_common.numberType.fullName',
-                    defaultMessage: 'Other number type',
-                  },
-                  name: {
-                    id: 'field.collectionobjects_common.numberType.name',
-                    defaultMessage: 'Type',
-                  },
-                }),
                 view: {
                   type: OptionPickerInput,
                   props: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -32,6 +32,12 @@ const template = (configContext) => {
           <Field name="deadFlag" subpath="ns2:collectionobjects_botgarden" />
           <Field name="deadDate" subpath="ns2:collectionobjects_botgarden" />
         </Row>
+        <Field name="otherNumberList">
+          <Field name="otherNumber">
+            <Field name="numberValue" />
+            <Field name="numberType" />
+          </Field>
+        </Field>
 
         <Field name="taxonomicIdentGroupList" subpath="ns2:collectionobjects_naturalhistory">
           <Field name="taxonomicIdentGroup">


### PR DESCRIPTION
**What does this do?**
The updates include:
* overriding `numberType` default configuration and mapping `source`  to the already existing `ucbgNumberTypes`
* added showing `otherNumberList` group of fields to the default collection object template

**Why are we doing this? (with JIRA link)**
We need to add the other number and other number type combination to the object record for UCB botgarden: https://collectionspace.atlassian.net/browse/DRYD-2035

Please note that:
* The group of fields is placed below the Accession number - Accession date... row. As it is in the cspace botgarden plugin profile:
<img width="1152" height="284" alt="image" src="https://github.com/user-attachments/assets/2dd48889-e404-4d76-8250-a2dae72a5481" />
* The Type field options are the already existing `ucbgNumberTypes`: 
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/blob/45ca1d9fa2cdc785d3ebcece126ca1bf2b5d70f8/src/plugins/recordTypes/collectionobject/optionLists.js#L4

**How should this be tested? Do these changes have associated tests?**
Please confirm 
* That the fields are being populated/searched as expected

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi tested locally.